### PR TITLE
Add java 18 base images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         scalaVersion: ['2.12.16', '2.13.8', '3.1.2']
-        javaTag: ['8u332', '11.0.15', '17.0.2', '11.0.14.1-oraclelinux8', 'graalvm-ce-21.3.0-java17', 'graalvm-ce-21.3.0-java11', 'graalvm-ce-21.2.0-java8', 'eclipse-temurin-17.0.2', 'eclipse-temurin-11.0.14.1']
+        javaTag: ['8u332', '11.0.15', '17.0.2', '18.0.1.1', '11.0.14.1-oraclelinux8', 'graalvm-ce-21.3.0-java17', 'graalvm-ce-21.3.0-java11', 'graalvm-ce-21.2.0-java8', 'eclipse-temurin-18.0.1', 'eclipse-temurin-17.0.2', 'eclipse-temurin-11.0.14.1']
         include:
           - javaTag: '8u332'
             dockerContext: 'debian'
@@ -30,6 +30,10 @@ jobs:
           - javaTag: '17.0.2'
             dockerContext: 'debian'
             baseImageTag: '17.0.2-jdk-bullseye'
+            platforms: 'linux/amd64,linux/arm64'
+          - javaTag: '18.0.1.1'
+            dockerContext: 'debian'
+            baseImageTag: '18.0.1.1-jdk-bullseye'
             platforms: 'linux/amd64,linux/arm64'
           - javaTag: '11.0.14.1-oraclelinux8'
             dockerContext: 'oracle'
@@ -46,6 +50,10 @@ jobs:
           - javaTag: 'graalvm-ce-21.2.0-java8'
             dockerContext: 'graalvm-ce'
             baseImageTag: 'java8-21.2.0'
+            platforms: 'linux/amd64,linux/arm64'
+          - javaTag: 'eclipse-temurin-18.0.1'
+            dockerContext: 'eclipse-temurin'
+            baseImageTag: '18.0.1_10-jdk'
             platforms: 'linux/amd64,linux/arm64'
           - javaTag: 'eclipse-temurin-17.0.2'
             dockerContext: 'eclipse-temurin'


### PR DESCRIPTION
Hey,

If you are okay with adding java 18 based `docker-sbt` images, then this PR adds the following base images:

* [openjdk:18.0.1.1-jdk-bullseye](https://hub.docker.com/layers/openjdk/library/openjdk/18.0.1.1-jdk-bullseye/images/sha256-92bcd2d7e64e29e5e60ceb5c1f42c92afe1e4c26e2c9dbd401a16cca98590913?context=explore)
* [eclipse-temurin:18.0.1_10-jdk](https://hub.docker.com/layers/eclipse-temurin/library/eclipse-temurin/18.0.1_10-jdk/images/sha256-fecc24180b0d88f6ce3dd1b5fa9d45634f5cdf1323856f10cd4dbc0e43d1166b?context=explore)

