### PR TITLE
Fix printing correct scala 3 version (#208)

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -37,7 +37,7 @@ RUN \
   chmod -R 755 /usr/share/scala && \
   ln -s /usr/share/scala/bin/* /usr/local/bin && \
   case $SCALA_VERSION in \
-    "3"*) echo "@main def main = println(util.Properties.versionMsg)" > test.scala ;; \
+    "3"*) echo '@main def main = println(s"Scala library version ${dotty.tools.dotc.config.Properties.versionNumberString}")' > test.scala ;; \
     *) echo "println(util.Properties.versionMsg)" > test.scala ;; \
   esac && \
   scala -nocompdaemon test.scala && rm test.scala

--- a/eclipse-temurin/Dockerfile
+++ b/eclipse-temurin/Dockerfile
@@ -37,7 +37,7 @@ RUN \
   chmod -R 755 /usr/share/scala && \
   ln -s /usr/share/scala/bin/* /usr/local/bin && \
   case $SCALA_VERSION in \
-    "3"*) echo "@main def main = println(util.Properties.versionMsg)" > test.scala ;; \
+    "3"*) echo '@main def main = println(s"Scala library version ${dotty.tools.dotc.config.Properties.versionNumberString}")' > test.scala ;; \
     *) echo "println(util.Properties.versionMsg)" > test.scala ;; \
   esac && \
   scala -nocompdaemon test.scala && rm test.scala

--- a/graalvm-ce/Dockerfile
+++ b/graalvm-ce/Dockerfile
@@ -39,7 +39,7 @@ RUN \
   chmod -R 755 /usr/share/scala && \
   ln -s /usr/share/scala/bin/* /usr/local/bin && \
   case $SCALA_VERSION in \
-    "3"*) echo "@main def main = println(util.Properties.versionMsg)" > test.scala ;; \
+    "3"*) echo '@main def main = println(s"Scala library version ${dotty.tools.dotc.config.Properties.versionNumberString}")' > test.scala ;; \
     *) echo "println(util.Properties.versionMsg)" > test.scala ;; \
   esac && \
   scala -nocompdaemon test.scala && rm test.scala

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -38,7 +38,7 @@ RUN \
   chmod -R 755 /usr/share/scala && \
   ln -s /usr/share/scala/bin/* /usr/local/bin && \
   case $SCALA_VERSION in \
-    "3"*) echo "@main def main = println(util.Properties.versionMsg)" > test.scala ;; \
+    "3"*) echo '@main def main = println(s"Scala library version ${dotty.tools.dotc.config.Properties.versionNumberString}")' > test.scala ;; \
     *) echo "println(util.Properties.versionMsg)" > test.scala ;; \
   esac && \
   scala -nocompdaemon test.scala && rm test.scala


### PR DESCRIPTION
- use 'dotty.tools.dotc.config.Properties.versionNumberString' instead of 'util.Properties.versionmsg' when scala 3.