### PR TITLE
adds eclipse-temurin:19_36-jdk-jammy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           'graalvm-ce-21.3.0-java17',
           'graalvm-ce-21.3.0-java11',
           'graalvm-ce-21.2.0-java8',
-          'eclipse-temurin:19_36'
+          'eclipse-temurin:19_36',
           'eclipse-temurin-18.0.2',
           'eclipse-temurin-17.0.4',
           'eclipse-temurin-11.0.16'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
           'graalvm-ce-21.3.0-java17',
           'graalvm-ce-21.3.0-java11',
           'graalvm-ce-21.2.0-java8',
+          'eclipse-temurin:19_36'
           'eclipse-temurin-18.0.2',
           'eclipse-temurin-17.0.4',
           'eclipse-temurin-11.0.16'
@@ -63,6 +64,10 @@ jobs:
             dockerContext: 'graalvm-ce'
             baseImageTag: 'java8-21.2.0'
             platforms: 'linux/amd64,linux/arm64'
+          - javaTag: 'eclipse-temurin:19_36'
+            dockerContext: 'eclipse-temurin'
+            baseImageTag: '19_36-jdk-jammy'
+            platforms: 'linux/amd64,linux/arm64'  
           - javaTag: 'eclipse-temurin-18.0.2'
             dockerContext: 'eclipse-temurin'
             baseImageTag: '18.0.2.1_1-jdk'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
             dockerContext: 'graalvm-ce'
             baseImageTag: 'java8-21.2.0'
             platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin:19_36'
+          - javaTag: 'eclipse-temurin-19_36'
             dockerContext: 'eclipse-temurin'
             baseImageTag: '19_36-jdk-jammy'
             platforms: 'linux/amd64,linux/arm64'  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           'graalvm-ce-21.3.0-java17',
           'graalvm-ce-21.3.0-java11',
           'graalvm-ce-21.2.0-java8',
-          'eclipse-temurin:19_36',
+          'eclipse-temurin-19_36',
           'eclipse-temurin-18.0.2',
           'eclipse-temurin-17.0.4',
           'eclipse-temurin-11.0.16'


### PR DESCRIPTION
Since JDK 19 has been released