### PR TITLE
upgrade to 11.0.17_8 to avoid CVE-2022-3602

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           'graalvm-ce-21.3.0-java17',
           'graalvm-ce-21.3.0-java11',
           'graalvm-ce-21.2.0-java8',
-          'eclipse-temurin-19_36',
+          'eclipse-temurin-19.0.1_10',
           'eclipse-temurin-18.0.2.1_1',
           'eclipse-temurin-17.0.5_8',
           'eclipse-temurin-11.0.17_8'
@@ -64,9 +64,9 @@ jobs:
             dockerContext: 'graalvm-ce'
             baseImageTag: 'java8-21.2.0'
             platforms: 'linux/amd64'
-          - javaTag: 'eclipse-temurin-19_36'
+          - javaTag: 'eclipse-temurin-19.0.1_10'
             dockerContext: 'eclipse-temurin'
-            baseImageTag: '19_36-jdk-jammy'
+            baseImageTag: '19.0.1_10-jdk-jammy'
             platforms: 'linux/amd64,linux/arm64'  
           - javaTag: 'eclipse-temurin-18.0.2.1_1'
             dockerContext: 'eclipse-temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           'graalvm-ce-21.2.0-java8',
           'eclipse-temurin-19_36',
           'eclipse-temurin-18.0.2.1_1',
-          'eclipse-temurin-17.0.4.1_1',
+          'eclipse-temurin-17.0.5_8',
           'eclipse-temurin-11.0.17_8'
         ]
         include:
@@ -72,9 +72,9 @@ jobs:
             dockerContext: 'eclipse-temurin'
             baseImageTag: '18.0.2.1_1-jdk'
             platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-17.0.4.1_1'
+          - javaTag: 'eclipse-temurin-17.0.5_8'
             dockerContext: 'eclipse-temurin'
-            baseImageTag: '17.0.4.1_1-jdk'
+            baseImageTag: '17.0.5_8-jdk'
             platforms: 'linux/amd64,linux/arm64'
           - javaTag: 'eclipse-temurin-11.0.17_8'
             dockerContext: 'eclipse-temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           'eclipse-temurin-19_36',
           'eclipse-temurin-18.0.2.1_1',
           'eclipse-temurin-17.0.4.1_1',
-          'eclipse-temurin-11.0.16.1_1'
+          'eclipse-temurin-11.0.17_8'
         ]
         include:
           - javaTag: 'openjdk-8u342'
@@ -76,9 +76,9 @@ jobs:
             dockerContext: 'eclipse-temurin'
             baseImageTag: '17.0.4.1_1-jdk'
             platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-11.0.16.1_1'
+          - javaTag: 'eclipse-temurin-11.0.17_8'
             dockerContext: 'eclipse-temurin'
-            baseImageTag: '11.0.16.1_1-jdk'
+            baseImageTag: '11.0.17_8-jdk'
             platforms: 'linux/amd64,linux/arm64'
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Update java 11 base image to avoid [CVE-2022-3602](http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-3602)
I am not sure if other images are vulnerable, but shouldn't a bot be updating these versions automatically?