### PR TITLE
add eclipse-temurin-8, drop eclipse-temurin-18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
           'graalvm-ce-22.3.0-b2-java17',
           'graalvm-ce-22.3.0-b2-java11',
           'eclipse-temurin-19.0.1_10',
-          'eclipse-temurin-18.0.2.1_1',
           'eclipse-temurin-17.0.5_8',
-          'eclipse-temurin-11.0.17_8'
+          'eclipse-temurin-11.0.17_8',
+          'eclipse-temurin-8u352-b08'
         ]
         include:
           # https://github.com/graalvm/container/pkgs/container/graalvm-ce
@@ -39,10 +39,6 @@ jobs:
           - javaTag: 'eclipse-temurin-19.0.1_10'
             dockerContext: 'eclipse-temurin'
             baseImageTag: '19.0.1_10-jdk-jammy'
-            platforms: 'linux/amd64,linux/arm64'  
-          - javaTag: 'eclipse-temurin-18.0.2.1_1'
-            dockerContext: 'eclipse-temurin'
-            baseImageTag: '18.0.2.1_1-jdk'
             platforms: 'linux/amd64,linux/arm64'
           - javaTag: 'eclipse-temurin-17.0.5_8'
             dockerContext: 'eclipse-temurin'
@@ -51,6 +47,10 @@ jobs:
           - javaTag: 'eclipse-temurin-11.0.17_8'
             dockerContext: 'eclipse-temurin'
             baseImageTag: '11.0.17_8-jdk'
+            platforms: 'linux/amd64,linux/arm64'
+          - javaTag: 'eclipse-temurin-8u352-b08'
+            dockerContext: 'eclipse-temurin'
+            baseImageTag: '8u352-b08-jdk'
             platforms: 'linux/amd64,linux/arm64'
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
We keep only latest LTS + latest, so we drop jdk18 as we have jdk19
Since we dropped openjdk-8 we had no more jdk8 image, found out that eclipse-temurin also has jdk8 images