### PR TITLE
Upgrade Scala version to 2.13.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scalaVersion: ['2.12.17', '2.13.10', '3.3.0']
+        scalaVersion: ['2.12.17', '2.13.11', '3.3.0']
         javaTag: [
           'graalvm-ce-22.3.0-b2-java17',
           'graalvm-ce-22.3.0-b2-java11',


### PR DESCRIPTION
Follow Scalas release, see:
- https://scala-lang.org/news/2.13.11
- https://github.com/scala/scala/releases/tag/v2.13.11