### PR TITLE
add graalvm-community

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         scalaVersion: ['2.12.18', '2.13.12', '3.3.1']
         javaTag: [
-          'graalvm-community-21.0.1'
+          'graalvm-community-21.0.1',
           'graalvm-ce-22.3.3-b1-java17',
           'graalvm-ce-22.3.3-b1-java11',
           'eclipse-temurin-jammy-21.0.1_12',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         scalaVersion: ['2.12.18', '2.13.12', '3.3.1']
         javaTag: [
+          'graalvm-community-21.0.1'
           'graalvm-ce-22.3.3-b1-java17',
           'graalvm-ce-22.3.3-b1-java11',
           'eclipse-temurin-jammy-21.0.1_12',
@@ -28,6 +29,11 @@ jobs:
           'eclipse-temurin-focal-11.0.21_9',
         ]
         include:
+          # https://github.com/graalvm/container/pkgs/container/graalvm-community
+          - javaTag: 'graalvm-community-21.0.1'
+            dockerContext: 'graalvm-community'
+            baseImageTag: '21.0.1-ol9'
+            platforms: 'linux/amd64,linux/arm64'
           # https://github.com/graalvm/container/pkgs/container/graalvm-ce
           - javaTag: 'graalvm-ce-22.3.3-b1-java17'
             dockerContext: 'graalvm-ce'

--- a/graalvm-community/Dockerfile
+++ b/graalvm-community/Dockerfile
@@ -1,0 +1,80 @@
+#
+# Scala and sbt Dockerfile
+#
+# https://github.com/sbt/docker-sbt
+#
+
+# Pull base image
+ARG BASE_IMAGE_TAG
+FROM ghcr.io/graalvm/graalvm-community:${BASE_IMAGE_TAG:-21.0.1-ol9}
+
+# Env variables
+ARG SCALA_VERSION
+ENV SCALA_VERSION ${SCALA_VERSION:-2.13.12}
+ARG SBT_VERSION
+ENV SBT_VERSION ${SBT_VERSION:-1.9.7}
+ENV JAVA_OPTS -XX:+UseG1GC
+ARG USER_ID
+ENV USER_ID ${USER_ID:-1001}
+ARG GROUP_ID
+ENV GROUP_ID ${GROUP_ID:-1001}
+
+# Install sbt
+RUN \
+  curl -fsL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar xfz - -C /usr/share && \
+  chown -R root:root /usr/share/sbt && \
+  chmod -R 755 /usr/share/sbt && \
+  ln -s /usr/share/sbt/bin/sbt /usr/local/bin/sbt
+
+# Install Scala
+## Piping curl directly in tar
+RUN \
+  case $SCALA_VERSION in \
+    "3"*) URL=https://github.com/lampepfl/dotty/releases/download/$SCALA_VERSION/scala3-$SCALA_VERSION.tar.gz SCALA_DIR=/usr/share/scala3-$SCALA_VERSION ;; \
+    *) URL=https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz SCALA_DIR=/usr/share/scala-$SCALA_VERSION ;; \
+  esac && \
+  curl -fsL $URL | tar xfz - -C /usr/share && \
+  mv $SCALA_DIR /usr/share/scala && \
+  chown -R root:root /usr/share/scala && \
+  chmod -R 755 /usr/share/scala && \
+  ln -s /usr/share/scala/bin/* /usr/local/bin && \
+  case $SCALA_VERSION in \
+    "3"*) echo '@main def main = println(s"Scala library version ${dotty.tools.dotc.config.Properties.versionNumberString}")' > test.scala ;; \
+    *) echo "println(util.Properties.versionMsg)" > test.scala ;; \
+  esac && \
+  scala -nocompdaemon test.scala && rm test.scala
+
+# Add and use user sbtuser
+RUN groupadd --gid $GROUP_ID sbtuser && useradd --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
+USER sbtuser
+
+# Switch working directory
+WORKDIR /home/sbtuser
+
+# Prepare sbt (warm cache)
+RUN \
+  sbt sbtVersion && \
+  mkdir -p project && \
+  echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
+  echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
+  echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
+  echo "case object Temp" > Temp.scala && \
+  sbt compile && \
+  rm -r project && rm build.sbt && rm Temp.scala && rm -r target
+
+# Link everything into root as well
+# This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
+USER root
+RUN \
+  rm -rf /tmp/..?* /tmp/.[!.]* * && \
+  ln -s /home/sbtuser/.cache /root/.cache && \
+  ln -s /home/sbtuser/.sbt /root/.sbt && \
+  if [ -d "/home/sbtuser/.ivy2" ]; then ln -s /home/sbtuser/.ivy2 /root/.ivy2; fi
+
+# Switch working directory back to root
+## Users wanting to use this container as non-root should combine the two following arguments
+## -u sbtuser
+## -w /home/sbtuser
+WORKDIR /root
+
+CMD sbt


### PR DESCRIPTION
Since Graalvm 17 changed the versioning, the base images are available under [graalvm-community](https://github.com/graalvm/container/pkgs/container/graalvm-community) tag. 

I propose to add this image to have support for the latest Java 21 LTS version.