### PR TITLE
Alpine based image for sbt-scala

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
           'eclipse-temurin-jammy-8u402-b06',
           'eclipse-temurin-focal-17.0.10_7',
           'eclipse-temurin-focal-11.0.22_7',
+          'eclipse-temurin-alpine-21.0.2_13',
+          'eclipse-temurin-alpine-17.0.10_7',
+          'eclipse-temurin-alpine-11.0.22_7',
         ]
         include:
           # https://github.com/graalvm/container/pkgs/container/graalvm-community
@@ -68,6 +71,21 @@ jobs:
             dockerContext: 'eclipse-temurin'
             baseImageTag: '11.0.22_7-jdk-focal'
             platforms: 'linux/amd64,linux/arm64'
+          - javaTag: 'eclipse-temurin-alpine-21.0.2_13'
+            dockerContext: 'eclipse-temurin'
+            dockerfile: 'alpine.Dockerfile'
+            baseImageTag: '21.0.2_13-jdk-alpine'
+            platforms: 'linux/amd64,linux/arm64'
+          - javaTag: 'eclipse-temurin-alpine-17.0.10_7'
+            dockerContext: 'eclipse-temurin'
+            dockerfile: 'alpine.Dockerfile'
+            baseImageTag: '17.0.10_7-jdk-alpine'
+            platforms: 'linux/amd64,linux/arm64'
+          - javaTag: 'eclipse-temurin-alpine-11.0.22_7'
+            dockerContext: 'eclipse-temurin'
+            dockerfile: 'alpine.Dockerfile'
+            baseImageTag: '11.0.22_7-jdk-alpine'
+            platforms: 'linux/amd64,linux/arm64'
     steps:
     - uses: actions/checkout@v4
     - name: Set up QEMU
@@ -100,6 +118,7 @@ jobs:
         context: ${{ matrix.dockerContext }}
         no-cache: true
         tags: ${{ steps.create_docker_tag.outputs.TAG }}
+        dockerfile: ${{ matrix.dockerfile }}
         build-args: |
           BASE_IMAGE_TAG=${{ matrix.baseImageTag }}
           SBT_VERSION=${{ steps.get_sbt_version.outputs.VERSION }}
@@ -130,6 +149,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: ${{ matrix.dockerContext }}
+        dockerfile: ${{ matrix.dockerfile }}
         tags: ${{ steps.create_docker_tag.outputs.TAG }}
         build-args: |
           BASE_IMAGE_TAG=${{ matrix.baseImageTag }}

--- a/eclipse-temurin/alpine.Dockerfile
+++ b/eclipse-temurin/alpine.Dockerfile
@@ -1,0 +1,80 @@
+# Use a multi-stage build to reduce the size of the final image
+FROM eclipse-temurin:${BASE_IMAGE_TAG:-21.0.2_13-jdk}-alpine as builder
+
+ARG SCALA_VERSION=3.4.0
+ARG SBT_VERSION=1.9.9
+ARG USER_ID=1001
+ARG GROUP_ID=1001
+ENV SCALA_HOME=/usr/share/scala
+
+# Install scala and sbt
+RUN apk add --no-cache --virtual=.build-dependencies wget ca-certificates bash curl bc && \
+    cd "/tmp" && \
+    case $SCALA_VERSION in \
+      "3"*) URL=https://github.com/lampepfl/dotty/releases/download/$SCALA_VERSION/scala3-$SCALA_VERSION.tar.gz SCALA_DIR=scala3-$SCALA_VERSION ;; \
+      *) URL=https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz SCALA_DIR=scala-$SCALA_VERSION ;; \
+    esac && \
+    curl -fsL $URL | tar xfz - -C /usr/share && \
+    mv /usr/share/$SCALA_DIR $SCALA_HOME && \
+    rm "/tmp/$SCALA_DIR/bin/"*.bat && \
+    ln -s "$SCALA_HOME/bin/"* "/usr/bin/" && \
+    update-ca-certificates && \
+    scala -version && \
+    case $SCALA_VERSION in \
+      "3"*) echo '@main def main = println(s"Scala library version ${dotty.tools.dotc.config.Properties.versionNumberString}")' > test.scala ;; \
+      *) echo "println(util.Properties.versionMsg)" > test.scala ;; \
+    esac && \
+    scala -nocompdaemon test.scala && rm test.scala && 
+
+RUN \
+    curl -fsL https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz | tar xfz - -C /usr/local && \
+    $(mv /usr/local/sbt-launcher-packaging-$SBT_VERSION /usr/local/sbt || true) && \
+    ln -s /usr/local/sbt/bin/* /usr/local/bin/ && \
+    sbt -Dsbt.rootdir=true -batch sbtVersion && \
+    apk del .build-dependencies && \
+    rm -rf "/tmp/"* && \
+    rm -rf /var/cache/apk/*
+
+# Start a new stage for the final image
+FROM eclipse-temurin:${BASE_IMAGE_TAG:-21.0.2_13-jdk}-alpine
+
+RUN apk add --no-cache bash git rpm
+
+COPY --from=builder /usr/share/scala /usr/share/scala
+COPY --from=builder /usr/local/sbt /usr/local/sbt
+COPY --from=builder /usr/local/bin/sbt /usr/local/bin/sbt
+
+# Add and use user sbtuser
+RUN addgroup -g $GROUP_ID sbtuser && adduser -D -G sbtuser -u $USER_ID sbtuser
+USER sbtuser
+
+# Switch working directory
+WORKDIR /home/sbtuser
+
+# Prepare sbt (warm cache)
+RUN \
+  sbt sbtVersion && \
+  mkdir -p project && \
+  echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
+  echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
+  echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
+  echo "case object Temp" > Temp.scala && \
+  sbt compile && \
+  rm -r project && rm build.sbt && rm Temp.scala && rm -r target
+
+# Link everything into root as well
+# This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
+USER root
+RUN \
+  rm -rf /tmp/..?* /tmp/.[!.]* * && \
+  ln -s /home/sbtuser/.cache /root/.cache && \
+  ln -s /home/sbtuser/.sbt /root/.sbt && \
+  if [ -d "/home/sbtuser/.ivy2" ]; then ln -s /home/sbtuser/.ivy2 /root/.ivy2; fi
+
+# Switch working directory back to root
+## Users wanting to use this container as non-root should combine the two following arguments
+## -u sbtuser
+## -w /home/sbtuser
+WORKDIR /root
+
+CMD sbt

--- a/eclipse-temurin/alpine.Dockerfile
+++ b/eclipse-temurin/alpine.Dockerfile
@@ -1,5 +1,5 @@
 # Use a multi-stage build to reduce the size of the final image
-FROM eclipse-temurin:${BASE_IMAGE_TAG:-21.0.2_13-jdk}-alpine as builder
+FROM eclipse-temurin:${BASE_IMAGE_TAG:-21.0.2_13-jdk} as builder
 
 ARG SCALA_VERSION=3.4.0
 ARG SBT_VERSION=1.9.9


### PR DESCRIPTION
Comparison:
`docker images`
![image](https://github.com/sbt/docker-sbt/assets/95964955/0733f65d-1d6f-4df4-99d2-c0b89813c8d3)

The image `eclipse-temurin-jammy-21.0.2_13` with base image `eclipse-temurin:21.0.2_13-jdk` is 977MB
The new image is 792MB
But moving
```
# Prepare sbt (warm cache)
RUN \
  sbt sbtVersion && \
  mkdir -p project && \
  echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
  echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
  echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
  echo "case object Temp" > Temp.scala && \
  sbt compile && \
  rm -r project && rm build.sbt && rm Temp.scala && rm -r target
  ```
  this code to build stage reduces the image size to 552MB (That still works good though I am not sure what will be the downside of moving this to build stage). 
Currently this pr has it outside of build stage I will move it to build stage to reduce size if you say so. The link to that branch is https://github.com/Carbrex/docker-sbt/blob/warm-stage-in-build/eclipse-temurin/alpine.Dockerfile
  
  I have also not been able to check for the build.yml changes as I dont know how to run them. Your help would be appreciated.
  Thanks for your time!