### PR TITLE
feat: add jdk 22, drop 8 and 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,20 +18,22 @@ jobs:
       matrix:
         scalaVersion: ['2.12.19', '2.13.13', '3.3.3', '3.4.0']
         javaTag: [
+          'graalvm-community-22.0.0',
           'graalvm-community-21.0.2',
           'graalvm-ce-22.3.3-b1-java17',
-          'graalvm-ce-22.3.3-b1-java11',
+          'eclipse-temurin-jammy-22_36',
           'eclipse-temurin-jammy-21.0.2_13',
           'eclipse-temurin-jammy-17.0.10_7',
-          'eclipse-temurin-jammy-11.0.22_7',
-          'eclipse-temurin-jammy-8u402-b06',
-          'eclipse-temurin-focal-17.0.10_7',
-          'eclipse-temurin-focal-11.0.22_7',
+          'eclipse-temurin-alpine-22_36',
           'eclipse-temurin-alpine-21.0.2_13',
           'eclipse-temurin-alpine-17.0.10_7'
         ]
         include:
           # https://github.com/graalvm/container/pkgs/container/graalvm-community
+          - javaTag: 'graalvm-community-22.0.0'
+            dockerContext: 'graalvm-community'
+            baseImageTag: '22.0.0-ol9'
+            platforms: 'linux/amd64,linux/arm64'
           - javaTag: 'graalvm-community-21.0.2'
             dockerContext: 'graalvm-community'
             baseImageTag: '21.0.2-ol9'
@@ -41,11 +43,11 @@ jobs:
             dockerContext: 'graalvm-ce'
             baseImageTag: 'ol9-java17-22.3.3-b1'
             platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'graalvm-ce-22.3.3-b1-java11'
-            dockerContext: 'graalvm-ce'
-            baseImageTag: 'ol9-java11-22.3.3-b1'
-            platforms: 'linux/amd64'
           # https://hub.docker.com/_/eclipse-temurin/tags
+          - javaTag: 'eclipse-temurin-jammy-22_36'
+            dockerContext: 'eclipse-temurin'
+            baseImageTag: '22_36-jdk-jammy'
+            platforms: 'linux/amd64,linux/arm64'
           - javaTag: 'eclipse-temurin-jammy-21.0.2_13'
             dockerContext: 'eclipse-temurin'
             baseImageTag: '21.0.2_13-jdk-jammy'
@@ -54,21 +56,11 @@ jobs:
             dockerContext: 'eclipse-temurin'
             baseImageTag: '17.0.10_7-jdk-jammy'
             platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-jammy-11.0.22_7'
+          # https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=alpine
+          - javaTag: 'eclipse-temurin-alpine-22_36'
             dockerContext: 'eclipse-temurin'
-            baseImageTag: '11.0.22_7-jdk-jammy'
-            platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-jammy-8u402-b06'
-            dockerContext: 'eclipse-temurin'
-            baseImageTag: '8u402-b06-jdk-jammy'
-            platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-focal-17.0.10_7'
-            dockerContext: 'eclipse-temurin'
-            baseImageTag: '17.0.10_7-jdk-focal'
-            platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-focal-11.0.22_7'
-            dockerContext: 'eclipse-temurin'
-            baseImageTag: '11.0.22_7-jdk-focal'
+            dockerfile: 'alpine.Dockerfile'
+            baseImageTag: '22_36-jdk-alpine'
             platforms: 'linux/amd64,linux/arm64'
           - javaTag: 'eclipse-temurin-alpine-21.0.2_13'
             dockerContext: 'eclipse-temurin'

--- a/eclipse-temurin/Dockerfile
+++ b/eclipse-temurin/Dockerfile
@@ -18,6 +18,14 @@ ENV USER_ID ${USER_ID:-1001}
 ARG GROUP_ID
 ENV GROUP_ID ${GROUP_ID:-1001}
 
+# Install dependencies
+# curl for downloading sbt and scala
+# git and rpm for sbt-native-packager (see https://github.com/sbt/docker-sbt/pull/114)
+RUN \
+  apt-get update && \
+  apt-get install -y curl git rpm && \
+  rm -rf /var/lib/apt/lists/*
+
 # Install sbt
 RUN \
   curl -fsL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar xfz - -C /usr/share && \
@@ -41,13 +49,6 @@ RUN \
     *) echo "println(util.Properties.versionMsg)" > test.scala ;; \
   esac && \
   scala -nocompdaemon test.scala && rm test.scala
-
-# Install git and rpm for sbt-native-packager (see https://github.com/sbt/docker-sbt/pull/114)
-RUN \
-  apt-get update && \
-  apt-get install git -y && \
-  apt-get install rpm -y && \
-  rm -rf /var/lib/apt/lists/*
 
 # Symlink java to have it available on sbtuser's PATH
 RUN ln -s /opt/java/openjdk/bin/java /usr/local/bin/java

--- a/eclipse-temurin/alpine.Dockerfile
+++ b/eclipse-temurin/alpine.Dockerfile
@@ -7,8 +7,11 @@ ARG USER_ID=1001
 ARG GROUP_ID=1001
 ENV SCALA_HOME=/usr/share/scala
 
-# Install scala and sbt
-RUN apk add --no-cache --virtual=.build-dependencies wget ca-certificates bash curl bc && \
+# Install dependencies
+RUN apk add --no-cache --virtual=.build-dependencies wget ca-certificates bash curl bc
+
+# Install scala
+RUN \
     cd "/tmp" && \
     case $SCALA_VERSION in \
       "3"*) URL=https://github.com/lampepfl/dotty/releases/download/$SCALA_VERSION/scala3-$SCALA_VERSION.tar.gz SCALA_DIR=scala3-$SCALA_VERSION ;; \
@@ -25,6 +28,7 @@ RUN apk add --no-cache --virtual=.build-dependencies wget ca-certificates bash c
     esac && \
     scala -nocompdaemon test.scala && rm test.scala
 
+# Install sbt
 RUN \
     curl -fsL https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz | tar xfz - -C /usr/local && \
     $(mv /usr/local/sbt-launcher-packaging-$SBT_VERSION /usr/local/sbt || true) && \


### PR DESCRIPTION
* drop jdk 8 (premier support ended on March 2022)
* drop jdk 11 (premier support ended on September 2023)
* drop ubuntu 20.04 LTS focal, keep only  22.04 LTS jammy (24.04 LTS noble on the horizon)