### PR TITLE
deps: Eclipse temurin base image updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,12 @@ jobs:
           'graalvm-community-22.0.1',
           'graalvm-community-21.0.2',
           'graalvm-ce-22.3.3-b1-java17',
-          'eclipse-temurin-jammy-22_36',
-          'eclipse-temurin-jammy-21.0.2_13',
-          'eclipse-temurin-jammy-17.0.10_7',
-          'eclipse-temurin-alpine-22_36',
-          'eclipse-temurin-alpine-21.0.2_13',
-          'eclipse-temurin-alpine-17.0.10_7'
+          'eclipse-temurin-23.0.1_11',
+          'eclipse-temurin-21.0.5_11',
+          'eclipse-temurin-17.0.13_11',
+          'eclipse-temurin-alpine-23.0.1_11',
+          'eclipse-temurin-alpine-21.0.5_11',
+          'eclipse-temurin-alpine-17.0.13_11'
         ]
         include:
           # https://github.com/graalvm/container/pkgs/container/graalvm-community
@@ -44,23 +44,23 @@ jobs:
             baseImageTag: 'ol9-java17-22.3.3-b1'
             platforms: 'linux/amd64,linux/arm64'
           # https://hub.docker.com/_/eclipse-temurin/tags
-          - javaTag: 'eclipse-temurin-jammy-22_36'
+          - javaTag: 'eclipse-temurin-23.0.1_11'
             dockerContext: 'eclipse-temurin'
-            baseImageTag: '22_36-jdk-jammy'
+            baseImageTag: '23.0.1_11-jdk'
             platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-jammy-21.0.2_13'
+          - javaTag: 'eclipse-temurin-21.0.5_11'
             dockerContext: 'eclipse-temurin'
-            baseImageTag: '21.0.2_13-jdk-jammy'
+            baseImageTag: '21.0.5_11-jdk'
             platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-jammy-17.0.10_7'
+          - javaTag: 'eclipse-temurin-17.0.13_11'
             dockerContext: 'eclipse-temurin'
-            baseImageTag: '17.0.10_7-jdk-jammy'
+            baseImageTag: '17.0.13_11-jdk'
             platforms: 'linux/amd64,linux/arm64'
           # https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=alpine
-          - javaTag: 'eclipse-temurin-alpine-22_36'
+          - javaTag: 'eclipse-temurin-alpine-23.0.1_11'
             dockerContext: 'eclipse-temurin'
             dockerfile: 'alpine.Dockerfile'
-            baseImageTag: '22_36-jdk-alpine'
+            baseImageTag: '23.0.1_11-jdk-alpine'
             platforms: 'linux/amd64,linux/arm64/v8'
           - javaTag: 'eclipse-temurin-alpine-21.0.2_13'
             dockerContext: 'eclipse-temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,15 +62,15 @@ jobs:
             dockerfile: 'alpine.Dockerfile'
             baseImageTag: '23.0.1_11-jdk-alpine'
             platforms: 'linux/amd64,linux/arm64/v8'
-          - javaTag: 'eclipse-temurin-alpine-21.0.2_13'
+          - javaTag: 'eclipse-temurin-alpine-21.0.5_11'
             dockerContext: 'eclipse-temurin'
             dockerfile: 'alpine.Dockerfile'
             baseImageTag: '21.0.2_13-jdk-alpine'
             platforms: 'linux/amd64,linux/arm64/v8'
-          - javaTag: 'eclipse-temurin-alpine-17.0.10_7'
+          - javaTag: 'eclipse-temurin-alpine-17.0.13_11'
             dockerContext: 'eclipse-temurin'
             dockerfile: 'alpine.Dockerfile'
-            baseImageTag: '17.0.10_7-jdk-alpine'
+            baseImageTag: '17.0.13_11-jdk-alpine'
             platforms: 'linux/amd64'
         exclude:
           # https://github.com/VirtusLab/scala-cli/issues/3130


### PR DESCRIPTION
Upgraded to the lastest base image version for all temurin based images.
Removed the `-jammy` base image selector to get the latest lts by default.

closes #309