### PR TITLE
Scala 3.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaVersion: ['2.12.20', '2.13.15', '3.3.4', '3.5.2']
+        scalaVersion: ['2.12.20', '2.13.15', '3.3.4', '3.6.2']
         javaTag: [
           'graalvm-community-22.0.1',
           'graalvm-community-21.0.2',


### PR DESCRIPTION
The Scala 3.6.2 binary is broken, see https://github.com/scala/scala3/issues/22196

Will update this once 3.6.3 is released